### PR TITLE
Add test for vincinv

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -26,9 +26,9 @@ class Ellipsoid(object):
         self.n2 = self.n ** 2
 
 
-grs80 = Ellipsoid(6378137, Decimal('298.25722210088'))
+grs80 = Ellipsoid(6378137, 298.25722210088)
 
-ans = Ellipsoid(6378160, Decimal('298.25'))
+ans = Ellipsoid(6378160, 298.25)
 
 
 # Projections

--- a/tests/test_geodesy.py
+++ b/tests/test_geodesy.py
@@ -1,0 +1,22 @@
+import unittest
+from conversions import dms2dd, dd2dms
+from geodesy import vincinv
+
+class TestGeodesy(unittest.TestCase):
+    def test_vincinv(self):
+        # Flinders Peak
+        lat1 = dms2dd(-37.57037203)
+        long1 = dms2dd(144.25295244)
+
+        # Buninyong
+        lat2 = dms2dd(-37.39101561)
+        long2 = dms2dd(143.55353839)
+
+        ell_dist, azimuth1to2, azimuth2to1 = vincinv(lat1, long1, lat2, long2)
+        self.assertEqual(round(ell_dist, 3), 54972.271)
+        self.assertEqual(round(dd2dms(azimuth1to2), 6), 306.520537)
+        self.assertEqual(round(dd2dms(azimuth2to1), 6), 127.102507)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,8 +5,9 @@ from conversions import dms2dd_v
 import numpy as np
 import os.path
 
+
 class TestTransforms(unittest.TestCase):
-    def test_transform(self):
+    def test_geo_grid_transform_interoperability(self):
         abs_path = os.path.abspath(os.path.dirname(__file__))
 
         test_geo_coords = np.genfromtxt(os.path.join(abs_path, 'resources/Test_Conversion_Geo.csv'),


### PR DESCRIPTION
I changed the constants `grs80` and `ans` to not be `Decimal`. There were some data type conflicts  with vincenty between `float`s and `decimal`s. Will this cause breakage in other areas? If so, we should probably have test coverage on those areas so we know if it breaks.

I've added a test for `vincinv`, with the data you sent me. I haven't added any for `vincdir` because I wasn't sure what numbers I should expect to get back for them. They were pretty off from the numbers used with `vincinv`. So there could be some bug there. Would be good to have an equality check between them.